### PR TITLE
Fix behavior with computed behavior

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,8 @@
-
 const _ = require('./utils')
 const computedBehavior = require('../src/index')
 const behaviorA = require('./tools/behaviorA')
+const behaviorWithComputed = require('./tools/behaviorWithComputed')
+const behaviorWithWatch = require('./tools/behaviorWithWatch')
 
 test('watch basics', () => {
   let funcTriggeringCount = 0
@@ -573,4 +574,42 @@ test('computed with wildcard observers', () => {
   const component = _.render(componentId)
   component.triggerLifeTime('attached')
   expect(_.match(component.dom, '<wx-view>2</wx-view>')).toBe(true)
+})
+
+test.skip('behavior with computed data', () => {
+  const componentId = _.load({
+    template: '<view>{{a}}+{{b}}={{c}}={{d}}</view>',
+    behaviors: [computedBehavior, behaviorWithComputed],
+    data: {
+      a: 1
+    },
+    computed: {
+      c(data) {
+        return data.a + data.b
+      }
+    }
+  })
+  const component = _.render(componentId)
+  component.triggerLifeTime('attached')
+  expect(_.match(component.dom, '<wx-view>1+3=4=4</wx-view>')).toBe(true)
+})
+
+test.skip('behavior with watch', () => {
+  const componentId = _.load({
+    template: '<view>{{a}}={{b}}={{c}}</view>',
+    behaviors: [computedBehavior, behaviorWithWatch],
+    data: {
+      a: 0,
+    },
+    watch: {
+      'a': function (a) {
+        this.setData({ b: a })
+      }
+    },
+  })
+  const component = _.render(componentId)
+  expect(_.match(component.dom, '<wx-view>0=0=0</wx-view>')).toBe(true)
+
+  component.setData({a: 1})
+  expect(_.match(component.dom, '<wx-view>1=1=1</wx-view>')).toBe(true)
 })

--- a/test/tools/behaviorWithComputed.js
+++ b/test/tools/behaviorWithComputed.js
@@ -1,0 +1,13 @@
+const computedBehavior = require('../../src/index')
+
+module.exports = Behavior({
+  behaviors: [computedBehavior],
+  data: {
+    b: 3
+  },
+  computed: {
+    d(data) {
+      return data.a + data.b
+    }
+  }
+})

--- a/test/tools/behaviorWithWatch.js
+++ b/test/tools/behaviorWithWatch.js
@@ -1,0 +1,14 @@
+const computedBehavior = require('../../src/index')
+
+module.exports = Behavior({
+  behaviors: [computedBehavior],
+  data: {
+    b: 0,
+    c: 0,
+  },
+  watch: {
+    'b': function (b) {
+      this.setData({ c: b })
+    }
+  },
+})


### PR DESCRIPTION
If one component/page instance has `computedBehavior` and another behavior which also has `computedBehavior`, it just won't work.

It adds two skipped unit tests which could be unskipped when https://github.com/wechat-miniprogram/j-component/pull/12 get merged and published.

This may also fix https://github.com/wechat-miniprogram/computed/issues/45.